### PR TITLE
Add ability to run AA rules manually on fabric

### DIFF
--- a/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantCommands.cs
+++ b/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantCommands.cs
@@ -1082,7 +1082,8 @@ namespace ArcGIS4LocalGovernment
                             {
                                 // Verify that this is a valid, visible layer and that this layer is editable
                                 fLayer = (IFeatureLayer)layer;
-                                if (fLayer.Valid && eLayers.IsEditable(fLayer))//fLayer.Visible &&
+                                bool bIsFabricLayer = (fLayer is ICadastralFabricSubLayer2);
+                                if (fLayer.Valid && (eLayers.IsEditable(fLayer) || bIsFabricLayer))//fLayer.Visible &&
                                 {
                                     // Verify that this layer has selected features  
                                     IFeatureClass fc = fLayer.FeatureClass;

--- a/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantEditorExtension.cs
+++ b/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantEditorExtension.cs
@@ -3026,7 +3026,11 @@ namespace ArcGIS4LocalGovernment
                                                         AAState.WriteLine("                  ERROR: Target layer is not a line layer. " + targetLayerName);
                                                         continue;
                                                     }
-
+                                                    if (targetLayer is ICadastralFabricSubLayer2)
+                                                    {
+                                                      AAState.WriteLine("                  ERROR: CREATE_PERP_LINE is not supported for a fabric layer target. " + targetLayerName);
+                                                      continue;
+                                                    }
 
                                                     for (int i = 0; i < sourceLayerNames.Length; i++)
                                                     {


### PR DESCRIPTION
This will allow the use of attribute assistant on parcel fabrics. For example, naming parcels based on geographic location, or based on overlapping the features from other layers. The code additions apply only to running the rules manually via the attribute assistant toolbar. The rule Create Perpendicular line has been filtered from running when the target is a fabric layer, and an error message is written to the log file. This rule would otherwise create invalid fabric lines, that are unattached to parcel records. No other instances of fabric corruption were found during testing.
