### PR TITLE
Fix for the Create rule getting applied twice

### DIFF
--- a/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantEditorExtension.cs
+++ b/Attribute Assistant Add In/AttributeAssistantAddIn/AttributeAssistantEditorExtension.cs
@@ -1649,6 +1649,19 @@ namespace ArcGIS4LocalGovernment
             try
             {
                 inFeature = obj as IFeature;
+
+                bool bIsFabricRecord = false;
+                if (inFeature != null)
+                {
+                    if (AAState._fabricObjectClassIds != null)
+                        bIsFabricRecord = AAState._fabricObjectClassIds.Contains(obj.Class.ObjectClassID);
+                    if (bIsFabricRecord)
+                    {
+                        if (inFeature.Shape.GeometryType == esriGeometryType.esriGeometryPolygon)
+                            return;// for parcels in fabrics, postpone the OnCreate event and let the OnChange test check if it's a new parcel
+                    }
+                }
+
                 sendEvent(obj, "ON_CREATE");
             }
             catch (Exception ex)


### PR DESCRIPTION
The new parcel creation process ends with a geometry update that is
fired as a separate OnChangeEvent. This was causing a double-event for
create rules related to the parcel fabric. The fix postpones the create
event to allow the already-implemented fabric OnChange logic to handle
the new parcels case.