### PR TITLE
Symbol name and Symbol Category depends on localization

### DIFF
--- a/ArcGISTemplateSharedFunctions/Globals.cs
+++ b/ArcGISTemplateSharedFunctions/Globals.cs
@@ -10582,7 +10582,8 @@ namespace A4LGSharedFunctions
                 pStyGallStor = (IStyleGalleryStorage)pStyGall;
 
                 //Set the styleset
-                pEnumStyGallItm = pStyGall.get_Items("Marker Symbols", stylename, stylecategory);
+                //pEnumStyGallItm = pStyGall.get_Items("Marker Symbols", stylename, stylecategory);
+                pEnumStyGallItm = pStyGall.get_Items("Marker Symbols", stylename, A4LGSharedFunctions.Localizer.GetString("Category_Style"));
                 pEnumStyGallItm.Reset();
 
 

--- a/ArcGISTemplateSharedFunctions/UserMessages.es-ES.resx
+++ b/ArcGISTemplateSharedFunctions/UserMessages.es-ES.resx
@@ -3480,4 +3480,10 @@
     <value>Copia de seguridad de la configuración actual</value>
     <comment>Needs translation</comment>
   </data>
+  <data name="Category_Style" xml:space="preserve">
+    <value>Predeterminado</value>
+  </data>
+  <data name="Point_Style" xml:space="preserve">
+    <value>Círculo 2</value>
+  </data>
 </root>

--- a/ArcGISTemplateSharedFunctions/UserMessages.es.resx
+++ b/ArcGISTemplateSharedFunctions/UserMessages.es.resx
@@ -3480,4 +3480,10 @@
     <value>Copia de seguridad de la configuración actual</value>
     <comment>Needs Translation</comment>
   </data>
+  <data name="Category_Style" xml:space="preserve">
+    <value>Predeterminado</value>
+  </data>
+  <data name="Point_Style" xml:space="preserve">
+    <value>Círculo 2</value>
+  </data>
 </root>

--- a/ArcGISTemplateSharedFunctions/UserMessages.resx
+++ b/ArcGISTemplateSharedFunctions/UserMessages.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActiveLayer" xml:space="preserve">
     <value>Active Layer:</value>
@@ -2639,5 +2639,11 @@
   </data>
   <data name="ConfigDlgBackupConfig" xml:space="preserve">
     <value>Backup existing configuration</value>
+  </data>
+  <data name="Category_Style" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="Point_Style" xml:space="preserve">
+    <value>Circle 2</value>
   </data>
 </root>

--- a/Water Utilities Desktop Tools/WaterUtilitiesDesktopFunctions/GeoNetTools.cs
+++ b/Water Utilities Desktop Tools/WaterUtilitiesDesktopFunctions/GeoNetTools.cs
@@ -6806,7 +6806,9 @@ namespace A4WaterUtilities
                 pTracePoint = pMxDoc.CurrentLocation;
 
 
-                pMarkerSym = Globals.FindMarkerSym("Esri.style", "Default", "Circle 2", pMxDoc);
+                //pMarkerSym = Globals.FindMarkerSym("Esri.style", "Default", "Circle 2", pMxDoc);
+                //Name Symbol depends on localization
+                pMarkerSym = Globals.FindMarkerSym("Esri.style", "Default", A4LGSharedFunctions.Localizer.GetString("Point_Style"), pMxDoc);
                 pRGBColor = Globals.GetColor(255, 0, 0);
 
 


### PR DESCRIPTION
Profiling tool fails in any language different from english. The  symbol name and category style depends on localization. I have added two items to default and spanish resources files (Point_Style and Category_Style) and i have made some code changes to make it work.