### PR TITLE
Fix V3001

### DIFF
--- a/Water Utilities Desktop Tools/WaterUtilitiesDesktopFunctions/AttributeTransferLoader.cs
+++ b/Water Utilities Desktop Tools/WaterUtilitiesDesktopFunctions/AttributeTransferLoader.cs
@@ -114,13 +114,13 @@ namespace A4WaterUtilities
 
                         for (int i = 0; i < attConfig.FromToFields.Length; i++)
                         {
-                            if (attConfig.FromToFields[i] == null || attConfig.FromToFields[i] == null)
+                            if (attConfig.FromToFields[i] == null)
                             {
                                 MessageBox.Show(A4LGSharedFunctions.Localizer.GetString("AttrTrasftLoadRError_1"));
                                 return;
 
                             }
-                            if (attConfig.FromToFields[i].SourceField == null || attConfig.FromToFields[i].SourceField == null)
+                            if (attConfig.FromToFields[i].SourceField == null || attConfig.FromToFields[i].TargetField == null)
                             {
                                 MessageBox.Show(A4LGSharedFunctions.Localizer.GetString("AttrTrasftLoadRError_1"));
                                 return;


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- There are identical sub-expressions 'attConfig.FromToFields[i] == null' to the left and to the right of the '||' operator. UtilitiesDesktopFunctions AttributeTransferLoader.cs 117

- There are identical sub-expressions 'attConfig.FromToFields[i].SourceField == null' to the left and to the right of the '||' operator. UtilitiesDesktopFunctions AttributeTransferLoader.cs 123